### PR TITLE
(fix) Tooltips: Simply update the hint for Cue mode preference

### DIFF
--- a/src/skin/legacy/tooltips.cpp
+++ b/src/skin/legacy/tooltips.cpp
@@ -507,7 +507,7 @@ void Tooltips::addStandardTooltips() {
     QString cueWhilePlaying = tr("Stops track at cue point, OR go to cue point and play after release (CUP mode).");
     QString cueWhileStopped = tr("Set cue point (Pioneer/Mixxx/Numark mode), set cue point and play after release (CUP mode) "
             "OR preview from it (Denon mode).");
-    QString cueHint = tr("Hint: Change the default cue mode in Preferences -> Interface.");
+    QString cueHint = tr("Hint: Change the default cue mode in Preferences -> Decks.");
     QString latchingPlay = tr("Is latching the playing state.");
 
     // Currently used for decks


### PR DESCRIPTION
The tooltip hint for the Cue button says the mode can be changed under Preferences -> Interface, but this is no longer true, now the setting is under Preferences -> Decks. (See line preferences/dialog/dlgprefdeckdlg.ui#L62).